### PR TITLE
Improve handling of iterables and array like

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1,5 +1,6 @@
 import { hasClass } from './support/decorators';
 import global from './support/global';
+import { ArrayLike } from './interfaces';
 import { forOf, Iterable, IterableIterator, ShimIterator } from './iterator';
 import { is as objectIs } from './object';
 import './Symbol';
@@ -35,7 +36,7 @@ export namespace Shim {
 		 * The first item in each tuple corresponds to the key of the map entry.
 		 * The second item corresponds to the value of the map entry.
 		 */
-		constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) {
+		constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {
 			if (iterable) {
 				forOf(iterable, (value: [K, V]) => {
 					this.set(value[0], value[1]);
@@ -169,7 +170,7 @@ export namespace Shim {
 @hasClass('es6-map', global.Map, Shim.Map)
 export default class Map<K, V> {
 	/* istanbul ignore next */
-	constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) { };
+	constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) { };
 
 	/* istanbul ignore next */
 	get size(): number { throw new Error('Abstract method'); };

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -1,5 +1,6 @@
 import { hasClass } from './support/decorators';
 import global from './support/global';
+import { ArrayLike } from './interfaces';
 import { forOf, IterableIterator, Iterable, ShimIterator } from './iterator';
 import './Symbol';
 
@@ -7,7 +8,7 @@ export namespace Shim {
 	export class Set<T> {
 		private _setData: T[] = [];
 
-		constructor(iterable?: Iterable<T> | ArrayLike<T>) {
+		constructor(iterable?: ArrayLike<T> | Iterable<T>) {
 			if (iterable) {
 				forOf(iterable, (value) => this.add(value));
 			}
@@ -74,7 +75,7 @@ export namespace Shim {
 @hasClass('es6-set', global.Set, Shim.Set)
 export default class Set<T> {
 	/* istanbul ignore next */
-	constructor(iterable?: Iterable<T> | ArrayLike<T>) { };
+	constructor(iterable?: ArrayLike<T> | Iterable<T>) { };
 
 	/* istanbul ignore next */
 	add(value: T): this { throw new Error('Abstract method'); };

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -1,5 +1,6 @@
 import { hasClass } from './support/decorators';
 import global from './support/global';
+import { ArrayLike } from './interfaces';
 import { forOf, Iterable } from './iterator';
 import './Symbol';
 
@@ -26,14 +27,12 @@ module Shim {
 	export class WeakMap<K, V> {
 		private _name: string;
 
-		constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) {
+		constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {
 			Object.defineProperty(this, '_name', {
 				value: generateName()
 			});
 			if (iterable) {
-				forOf(iterable, (value: [K, V]) => {
-					this.set(value[0], value[1]);
-				});
+				forOf(iterable, ([ key, value ]: [K, V]) => this.set(key, value));
 			}
 		}
 
@@ -82,7 +81,7 @@ module Shim {
 @hasClass('es6-weakmap', global.WeakMap, Shim.WeakMap)
 export default class WeakMap<K, V> {
 	/* istanbul ignore next */
-	constructor(iterable?: any) {}
+	constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {}
 
 	/* istanbul ignore next */
 	delete(key: K): boolean { throw new Error(); }

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,16 +1,17 @@
 import has from './support/has';
 import { wrapNative } from './support/util';
+import { ArrayLike } from './interfaces';
 import { forOf, isArrayLike, isIterable, Iterable } from './iterator';
 import { MAX_SAFE_INTEGER as maxSafeInteger } from './number';
 
-export interface MapCallback<T> {
+export interface MapCallback<T, U> {
 	/**
 	 * A callback function when mapping
 	 *
 	 * @param element The element that is currently being mapped
 	 * @param index The current index of the element
 	 */
-	(element: T, index: number): T;
+	(element: T, index: number): U;
 }
 
 export interface FindCallback<T> {
@@ -76,9 +77,7 @@ function normalizeOffset(value: number, length: number): number {
  * the functionality is required or not.
  */
 export namespace Shim {
-	export function from(arrayLike: string, mapFunction?: MapCallback<string>, thisArg?: {}): Array<string>;
-	export function from<T>(arrayLike: Iterable<T> | ArrayLike<T>, mapFunction?: MapCallback<T>, thisArg?: {}): Array<T>;
-	export function from<T>(arrayLike: (string | Iterable<T> | ArrayLike<T>), mapFunction?: MapCallback<T>, thisArg?: {}): Array<T> {
+	export function from(arrayLike: Iterable<any> | ArrayLike<any>, mapFunction?: MapCallback<any, any>, thisArg?: any): Array<any> {
 		if (arrayLike == null) {
 			throw new TypeError('from: requires an array-like object');
 		}
@@ -88,7 +87,7 @@ export namespace Shim {
 		}
 
 		/* tslint:disable-next-line:variable-name */
-		const Constructor: any = this;
+		const Constructor: ArrayConstructor = this;
 		const length: number = toLength((<any> arrayLike).length);
 		// Support extension
 		const array: any[] = (typeof Constructor === 'function') ? <any[]> Object(new Constructor(length)) : new Array(length);
@@ -98,7 +97,7 @@ export namespace Shim {
 		}
 
 		let i = 0;
-		forOf(<any> arrayLike, function (value: T): void {
+		forOf(arrayLike, function (value): void {
 			array[i] = mapFunction ? mapFunction(value, i) : value;
 			i++;
 		});
@@ -110,7 +109,7 @@ export namespace Shim {
 		return array;
 	}
 
-	export function of(...items: any[]): any[] {
+	export function of<T>(...items: T[]): Array<T> {
 		return Array.prototype.slice.call(items);
 	}
 
@@ -203,17 +202,41 @@ export namespace Shim {
 /* ES6 Array static methods */
 
 export interface From {
-	(arrayLike: string, mapFunction?: MapCallback<string>, thisArg?: {}): Array<string>;
-	<T>(arrayLike: Iterable<T> | ArrayLike<T>, mapFunction?: MapCallback<T>, thisArg?: {}): Array<T>;
 	/**
 	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
 	 *
-	 * @param arrayLike An array-like or iterable object to convert to an array
+	 * @param arrayLike An array-like object to convert to an array
 	 * @param mapFunction A map function to call on each element in the array
 	 * @param thisArg The execution context for the map function
 	 * @return The new Array
 	 */
-	<T>(arrayLike: (string | Iterable<T> | ArrayLike<T>), mapFunction?: MapCallback<T>, thisArg?: {}): Array<T>;
+	<T, U>(arrayLike: ArrayLike<T>, mapFunction: MapCallback<T, U>, thisArg?: any): Array<U>;
+
+	/**
+	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
+	 *
+	 * @param iterable An iterable object to convert to an array
+	 * @param mapFunction A map function to call on each element in the array
+	 * @param thisArg The execution context for the map function
+	 * @return The new Array
+	 */
+	<T, U>(iterable: Iterable<T>, mapFunction: MapCallback<T, U>, thisArg?: any): Array<U>;
+
+	/**
+	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
+	 *
+	 * @param arrayLike An array-like object to convert to an array
+	 * @return The new Array
+	 */
+	<T>(arrayLike: ArrayLike<T>): Array<T>;
+
+	/**
+	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
+	 *
+	 * @param arrayLike An iterable object to convert to an array
+	 * @return The new Array
+	 */
+	<T>(iterable: Iterable<T>): Array<T>;
 }
 
 export const from: From = has('es6-array-from')
@@ -226,7 +249,7 @@ export const from: From = has('es6-array-from')
  * @param arguments Any number of arguments for the array
  * @return An array from the given arguments
  */
-export const of: (...items: any[]) => any[] = has('es6-array-of')
+export const of: <T>(...items: T[]) => Array<T> = has('es6-array-of')
 	? (<any> Array).of
 	: Shim.of;
 
@@ -254,7 +277,7 @@ export const copyWithin: <T>(target: ArrayLike<T>, offset: number, start: number
  * @param end The (exclusive) index at which to stop filling
  * @return The filled target
  */
-export const fill: <T>(target: ArrayLike<T>, value: any, start?: number, end?: number) => ArrayLike<T> = has('es6-array-fill')
+export const fill: <T>(target: ArrayLike<T>, value: T, start?: number, end?: number) => ArrayLike<T> = has('es6-array-fill')
 	? wrapNative((<any> Array.prototype).fill)
 	: Shim.fill;
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -5,3 +5,8 @@ export interface Thenable<T> {
 	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error?: any) => U | Thenable<U>): Thenable<U>;
 	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error?: any) => void): Thenable<U>;
 }
+
+export interface ArrayLike<T> {
+	length: number;
+	[n: number]: T;
+}

--- a/tests/unit/Map.ts
+++ b/tests/unit/Map.ts
@@ -30,7 +30,7 @@ registerSuite({
 
 		'iterator data'() {
 			assert.doesNotThrow(function () {
-				map = new Map<number, string>(<any> new ShimIterator<[number, string]>({
+				map = new Map(new ShimIterator<[number, string]>({
 					length: 1,
 					0: [ 3, 'bar' ]
 				}));
@@ -40,14 +40,14 @@ registerSuite({
 
 	clear: {
 		'empty map'() {
-			map = new Map<void, void>();
+			map = new Map();
 			assert.doesNotThrow(function () {
 				map.clear();
 			});
 		},
 
 		'non-empty map'() {
-			map = new Map<number, string>([
+			map = new Map([
 				[ 3, 'abc' ]
 			]);
 			map.clear();
@@ -58,7 +58,7 @@ registerSuite({
 
 	'delete': {
 		before() {
-			map = new Map<number, string>([
+			map = new Map([
 				[ 3, 'abc' ],
 				[ 4, 'def' ]
 			]);
@@ -136,7 +136,7 @@ registerSuite({
 
 	get: {
 		before() {
-			map = new Map<number, string>([
+			map = new Map([
 				[ 0, 'a' ],
 				[ 8, 'b' ],
 				[ NaN, 'c' ]

--- a/tests/unit/Set.ts
+++ b/tests/unit/Set.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Set from 'src/Set';
-import { forOf } from 'src/iterator';
+import { forOf, ShimIterator } from 'src/iterator';
 
 registerSuite({
 	name: 'Set',
@@ -15,6 +15,21 @@ registerSuite({
 
 		'iterable'() {
 			const set = new Set([1, 2, 3, 2]);
+			assert.isTrue(set.has(1));
+			assert.isTrue(set.has(2));
+			assert.isTrue(set.has(3));
+			assert.isFalse(set.has(4));
+			assert.strictEqual(set.size, 3);
+		},
+
+		'arraylike'() {
+			const set = new Set(new ShimIterator({
+				0: 1,
+				1: 2,
+				2: 3,
+				3: 2,
+				length: 4
+			}));
 			assert.isTrue(set.has(1));
 			assert.isTrue(set.has(2));
 			assert.isTrue(set.has(3));

--- a/tests/unit/WeakMap.ts
+++ b/tests/unit/WeakMap.ts
@@ -10,7 +10,7 @@ registerSuite({
 
 	construction: {
 		'no arguments'() {
-			const map: WeakMap<any, any> = new WeakMap();
+			const map = new WeakMap();
 			assert(map, 'map should exist');
 			assert.instanceOf(map, WeakMap, 'map should be an instance of WeakMap');
 		},
@@ -18,7 +18,7 @@ registerSuite({
 		'array'() {
 			const key1: Key = {};
 			const key2: Key = {};
-			const map = new WeakMap<Key, number>([
+			const map = new WeakMap([
 				[ key1, 1 ],
 				[ key2, 2 ]
 			]);
@@ -32,10 +32,11 @@ registerSuite({
 		'iterable'() {
 			const key1: Key = {};
 			const key2: Key = {};
-			const map = new WeakMap<Key, number>(new ShimIterator<[Key, number]>([
-				[ key1, 1 ],
-				[ key2, 2 ]
-			]));
+			const map = new WeakMap(new ShimIterator<[Key, number]>({
+				0: [ key1, 1 ],
+				1: [ key2, 2 ],
+				length: 2
+			}));
 
 			assert.isTrue(map.has(key1), 'key1 should be in map');
 			assert.isTrue(map.has(key2), 'key2 should be in map');
@@ -46,7 +47,7 @@ registerSuite({
 
 	'.delete'() {
 		const key: Key = {};
-		const map = new WeakMap<Key, number>([
+		const map = new WeakMap([
 			[ key, 1 ]
 		]);
 
@@ -58,7 +59,7 @@ registerSuite({
 	'.get'() {
 		const key1: Key = {};
 		const key2: Key = Object.create(key1);
-		const map = new WeakMap<Key, number>([
+		const map = new WeakMap([
 			[ key1, 1 ],
 			[ key2, 2 ]
 		]);
@@ -81,7 +82,7 @@ registerSuite({
 		const key1: Key = {};
 		const key2: Key = Object.create(key1);
 		const key3: Key = {};
-		const map = new WeakMap<Key, number>([
+		const map = new WeakMap([
 			[ key1, 1 ],
 			[ key3, 3 ]
 		]);


### PR DESCRIPTION
**Type:** bug

**Description:** 

This provides several changes that improves the run-time handling of iterables and array like structures, as well as improves the handling of type inference at design time in TypeScript.

It also improves explicit test coverage of dojo/shim/iterator.

**Related Issue:** #3, #4

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
