### PR TITLE
Fix typing for array::from()

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -205,38 +205,20 @@ export interface From {
 	/**
 	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
 	 *
-	 * @param arrayLike An array-like object to convert to an array
+	 * @param source An array-like or iterable object to convert to an array
 	 * @param mapFunction A map function to call on each element in the array
 	 * @param thisArg The execution context for the map function
 	 * @return The new Array
 	 */
-	<T, U>(arrayLike: ArrayLike<T>, mapFunction: MapCallback<T, U>, thisArg?: any): Array<U>;
+	<T, U>(source: ArrayLike<T> | Iterable<T>, mapFunction: MapCallback<T, U>, thisArg?: any): Array<U>;
 
 	/**
 	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
 	 *
-	 * @param iterable An iterable object to convert to an array
-	 * @param mapFunction A map function to call on each element in the array
-	 * @param thisArg The execution context for the map function
+	 * @param source An array-like or iterable object to convert to an array
 	 * @return The new Array
 	 */
-	<T, U>(iterable: Iterable<T>, mapFunction: MapCallback<T, U>, thisArg?: any): Array<U>;
-
-	/**
-	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
-	 *
-	 * @param arrayLike An array-like object to convert to an array
-	 * @return The new Array
-	 */
-	<T>(arrayLike: ArrayLike<T>): Array<T>;
-
-	/**
-	 * The Array.from() method creates a new Array instance from an array-like or iterable object.
-	 *
-	 * @param arrayLike An iterable object to convert to an array
-	 * @return The new Array
-	 */
-	<T>(iterable: Iterable<T>): Array<T>;
+	<T>(source: ArrayLike<T> | Iterable<T>): Array<T>;
 }
 
 export const from: From = has('es6-array-from')

--- a/tests/unit/array.ts
+++ b/tests/unit/array.ts
@@ -12,8 +12,7 @@ function mixin<T extends { [key: string]: any }, U extends { [key: string]: any 
 	return <any> destination;
 }
 
-function assertFrom<T>(arrayable: ArrayLike<T>, expected: T[]): void;
-function assertFrom<T>(arrayable: Iterable<T>, expected: T[]): void;
+function assertFrom<T>(arrayable: ArrayLike<T> | Iterable<T>, expected: T[]): void;
 function assertFrom(arrayable: any, expected: any[]): void {
 	let actual = array.from(arrayable);
 	assert.isArray(actual);
@@ -94,7 +93,7 @@ registerSuite({
 		},
 
 		'from array-like': (function () {
-			let obj: any;
+			let obj: { [item: string]: any; length: number; };
 
 			return {
 				beforeEach: function () {
@@ -207,6 +206,25 @@ registerSuite({
 			};
 			let actual = array.from([ 1, 2, 3 ], thing.mapFunction, thing);
 			assert.isArray(actual);
+			assert.deepEqual([ 0, 1, 2 ], actual);
+		},
+
+		'with union type': function () {
+			let thing: ArrayLike<number> | Iterable<number> = {
+				'0': 0,
+				'1': 1,
+				'2': 2,
+				length: 3,
+				[Symbol.iterator]() {
+					return {
+						index: 0,
+						next(this: any) {
+							return this.index < 3 ? { value: this.index++, done: false } : { done: true, value: undefined };
+						}
+					};
+				}
+			};
+			let actual = array.from(thing);
 			assert.deepEqual([ 0, 1, 2 ], actual);
 		}
 	}),


### PR DESCRIPTION
**Type:** bug

**Description:** 

Fixes `array::from()` typings.

**Related Issue:** #9

Please review this checklist before submitting your PR:
- [x] There is a related issue
- [x] All contributors have signed a CLA
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [x] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged

Now properly accepts union types that are both ArrayLike and
Iterable.  Adds a test to ensure typings are handled
properly.
