### PR TITLE
Promise callbacks always receive a value

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -280,8 +280,8 @@ export class PromiseShim<T> implements Thenable<T> {
 	private resolvedValue: any;
 
 	then: <U>(
-		onFulfilled?: (value?: T) => (U | Thenable<U>),
-		onRejected?: (reason?: Error) => (U | Thenable<U>)
+		onFulfilled?: (value: T) => (U | Thenable<U>),
+		onRejected?: (reason: Error) => (U | Thenable<U>)
 	) => PromiseShim<U>;
 
 	[Symbol.toStringTag]: string = 'Promise';
@@ -431,8 +431,8 @@ export default class Promise<T> implements Thenable<T> {
 	/**
 	 * Adds a callback to the promise to be invoked when the asynchronous operation throws an error.
 	 */
-	catch<U>(onRejected: (reason?: Error) => (U | Thenable<U>)): Promise<U>;
-	catch<U>(onRejected: (reason?: Error) => void): Promise<U> {
+	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): Promise<U>;
+	catch<U>(onRejected: (reason: Error) => void): Promise<U> {
 		return this.then<U>(null, onRejected);
 	}
 
@@ -477,8 +477,8 @@ export default class Promise<T> implements Thenable<T> {
 	/**
 	 * Adds a callback to the promise to be invoked when the asynchronous operation completes successfully.
 	 */
-	then<U>(onFulfilled?: ((value?: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason?: Error) => void): Promise<U>;
-	then<U>(onFulfilled?: ((value?: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason?: Error) => (U | Thenable<U>)): Promise<U> {
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason: Error) => void): Promise<U>;
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): Promise<U> {
 		return (<typeof Promise> this.constructor).copy(this.promise.then(onFulfilled, onRejected));
 	}
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,8 +2,8 @@
  * Thenable represents any object with a callable `then` property.
  */
 export interface Thenable<T> {
-	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error?: any) => U | Thenable<U>): Thenable<U>;
-	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error?: any) => void): Thenable<U>;
+	then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
+	then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
 }
 
 export interface ArrayLike<T> {


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Fix optional typings for callback arguments, they'll always receive a
value / reason. With the old typing strict null checks would always
allow for the value to be undefined.

Please review this checklist before submitting your PR:
- [ ] There is a related issue
- [x] All contributors have signed a CLA
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [ ] The code passes the CI tests
- [ ] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
