### PR TITLE
Letting WeakMap shim support frozen keys, fixes #25

### DIFF
--- a/tests/unit/WeakMap.ts
+++ b/tests/unit/WeakMap.ts
@@ -47,21 +47,32 @@ registerSuite({
 
 	'.delete'() {
 		const key: Key = {};
+		const frozen: Key = {};
+		Object.freeze(frozen);
+
 		const map = new WeakMap([
-			[ key, 1 ]
+			[ key, 1 ],
+			[ frozen, 2 ]
 		]);
 
 		assert.isTrue(map.delete(key), 'deleting key should return true');
 		assert.isFalse(map.has(key), 'key should not be in map');
 		assert.isFalse(map.delete(key), 'deleting key again should return false');
+		assert.isTrue(map.delete(frozen), 'deleting frozen should return true');
+		assert.isFalse(map.has(frozen), 'frozen should not be in map');
+		assert.isFalse(map.delete(frozen), 'deleting frozen again should return false');
 	},
 
 	'.get'() {
 		const key1: Key = {};
 		const key2: Key = Object.create(key1);
+		const frozen: Key = {};
+		Object.freeze(frozen);
+
 		const map = new WeakMap([
 			[ key1, 1 ],
-			[ key2, 2 ]
+			[ key2, 2 ],
+			[ frozen, 3]
 		]);
 
 		assert.strictEqual(map.get(key1), 1, 'key1 should equal 1');
@@ -76,26 +87,37 @@ registerSuite({
 
 		assert.strictEqual(map.get(key1), undefined, 'key1 should still be undefined');
 		assert.strictEqual(map.get(key2), undefined, 'key2 should be undefined');
+
+		assert.strictEqual(map.get(frozen), 3, 'frozen should be 3');
 	},
 
 	'.has'() {
 		const key1: Key = {};
 		const key2: Key = Object.create(key1);
 		const key3: Key = {};
+		const frozen: Key = {};
+
+		Object.freeze(frozen);
+
 		const map = new WeakMap([
 			[ key1, 1 ],
-			[ key3, 3 ]
+			[ key3, 3 ],
+			[ frozen, 5]
 		]);
 
 		assert.isTrue(map.has(key1), 'key1 should be in map');
 		assert.isFalse(map.has(key2), 'key2 should not be in map');
 		assert.isTrue(map.has(key3), 'key3 should be in map');
+		assert.isTrue(map.has(frozen), 'frozen should be in the map');
 	},
 
 	'.set'() {
 		const key1: Key = {};
 		const key2: Key = Object.create(key1);
+		const frozen = {};
 		const map = new WeakMap<Key, number>();
+
+		Object.freeze(frozen);
 
 		assert.isFalse(map.has(key1), 'key1 should not be in map');
 		assert.isFalse(map.has(key2), 'key2 should not be in map');
@@ -135,6 +157,10 @@ registerSuite({
 		});
 		assert.doesNotThrow(function () {
 			map.set([], 1);
+		});
+
+		assert.doesNotThrow(function() {
+			map.set(frozen, 1);
 		});
 	}
 });


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Adding support for frozen objects as keys in the WeakMap shim. The only way I could see to do this was with a plain old array of frozen keys, and manually searching them when we need a key. This shouldn't cause _any_ performance impact for non-frozen keys, just frozen ones.

**Related Issue:** #25 

Please review this checklist before submitting your PR:
- [x] There is a related issue
- [x] All contributors have signed a CLA
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [x] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
