### PR TITLE
Fixing Map, Promise has test methods to work on iOS 8.4, fixes #37

### DIFF
--- a/src/support/has.ts
+++ b/src/support/has.ts
@@ -38,6 +38,7 @@ add('es6-string-includes', 'includes' in global.String.prototype);
 /* Math */
 
 add('es6-math-acosh', typeof global.Math.acosh === 'function');
+add('es6-math-clz32', typeof global.Math.clz32 === 'function');
 add('es6-math-imul', () => {
 	if ('imul' in global.Math) {
 		/* Some versions of Safari on ios do not properly implement this */
@@ -47,7 +48,7 @@ add('es6-math-imul', () => {
 });
 
 /* Promise */
-add('es6-promise', typeof global.Promise !== 'undefined');
+add('es6-promise', typeof global.Promise !== 'undefined' && typeof global.Symbol !== 'undefined');
 
 /* Set */
 add('es6-set', () => {
@@ -62,10 +63,19 @@ add('es6-set', () => {
 /* Map */
 add('es6-map', function () {
 	if (typeof global.Map === 'function') {
-		/* IE11 and older versions of Safari are missing critical ES6 Map functionality */
-		const map = new global.Map([ [0, 1] ]);
-		return map.has(0) && typeof map.keys === 'function' &&
-			typeof map.values === 'function' && typeof map.entries === 'function';
+		/*
+		IE11 and older versions of Safari are missing critical ES6 Map functionality
+		We wrap this in a try/catch because sometimes the Map constructor exists, but does not
+		take arguments (iOS 8.4)
+		 */
+		try {
+			const map = new global.Map([ [0, 1] ]);
+			return map.has(0) && typeof map.keys === 'function' &&
+				typeof map.values === 'function' && typeof map.entries === 'function';
+		}
+		catch (e) {
+			return false;
+		}
 	}
 	return false;
 });

--- a/src/support/has.ts
+++ b/src/support/has.ts
@@ -74,6 +74,7 @@ add('es6-map', function () {
 				typeof map.values === 'function' && typeof map.entries === 'function';
 		}
 		catch (e) {
+			/* istanbul ignore next: not testing on iOS at the moment */
 			return false;
 		}
 	}

--- a/tests/unit/native/math.ts
+++ b/tests/unit/native/math.ts
@@ -5,7 +5,7 @@ import has from '../../../src/support/has';
 registerSuite({
 	name: 'native/math',
 	'verify API'(this: any) {
-		if (!has('es6-math-acosh')) {
+		if (!has('es6-math-acosh') || !has('es6-math-clz32')) {
 			this.skip('No native support');
 		}
 		const dfd = this.async();


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

This is a fix for the Map tester failing to detect a non-compatible `Map` on iOS 8.4. The problem is that `Map` exists, but does accept take any arguments.

Once I made the error go away for this, it turns out there were some other incompatibilities, so I added another check for the `Math` library (iOS is missing the `czlr32` method) and made the `Promise` test a little bit more specific because iOS 8 supports `Promise` but not `Iterator` (which we use to pass to `Promise.all`)

**Related Issue:** #37 

Please review this checklist before submitting your PR:
- [x] There is a related issue
- [x] All contributors have signed a CLA
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [ ] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
