### PR TITLE
Add object#keys

### DIFF
--- a/src/native/object.ts
+++ b/src/native/object.ts
@@ -19,6 +19,10 @@ export const getOwnPropertySymbols: (o: any) => symbol[] = (<any> Object).getOwn
  *
  * @param o The object to return the properties for
  */
-/* intentionally detecting `getOwnPropertySymbols` because we should should provide the shim
- * when there is no support for symbols */
 export const getOwnPropertyNames: (o: any) => string[] = Object.getOwnPropertyNames;
+
+/**
+ * Returns the names of the enumerable properties and methods of an object.
+ * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+ */
+export const keys: (o: any) => string[] = Object.keys;

--- a/src/object.ts
+++ b/src/object.ts
@@ -16,6 +16,10 @@ namespace Shim {
 	export function getOwnPropertyNames(o: any): string[] {
 		return Object.getOwnPropertyNames(o).filter((key) => !Boolean(key.match(/^@@.+/)));
 	}
+
+	export function keys(o: any): string[] {
+		return Object.keys(o).filter((key) => !Boolean(key.match(/^@@.+/)));
+	}
 }
 
 /**
@@ -30,11 +34,16 @@ export const is: (value1: any, value2: any) => boolean = 'is' in Object
 	: Shim.is;
 
 /**
+ * Detect if there is native support for Symbol properties in Object
+ */
+const hasGetOwnPropertySymbols = 'getOwnPropertySymbols' in Object;
+
+/**
  * Returns an array of own properties who key is a symbol
  *
  * @param o The object to return the properties for
  */
-export const getOwnPropertySymbols: (o: any) => symbol[] = 'getOwnPropertySymbols' in Object
+export const getOwnPropertySymbols: (o: any) => symbol[] = hasGetOwnPropertySymbols
 	? (<any> Object).getOwnPropertySymbols
 	: Shim.getOwnPropertySymbols;
 
@@ -45,6 +54,16 @@ export const getOwnPropertySymbols: (o: any) => symbol[] = 'getOwnPropertySymbol
  */
 /* intentionally detecting `getOwnPropertySymbols` because we should should provide the shim
  * when there is no support for symbols */
-export const getOwnPropertyNames: (o: any) => string[] = 'getOwnPropertySymbols' in Object
+export const getOwnPropertyNames: (o: any) => string[] = hasGetOwnPropertySymbols
 	? Object.getOwnPropertyNames
 	: Shim.getOwnPropertyNames;
+
+/**
+ * Returns the names of the enumerable properties and methods of an object.
+ * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+ */
+/* intentionally detecting `getOwnPropertySymbols` because we should should provide the shim
+ * when there is no support for symbols */
+export const keys: (o: any) => string[] = hasGetOwnPropertySymbols
+	? Object.keys
+	: Shim.keys;

--- a/tests/unit/native/object.ts
+++ b/tests/unit/native/object.ts
@@ -16,9 +16,10 @@ registerSuite({
 			[
 				'is',
 				'getOwnPropertySymbols',
-				'getOwnPropertyNames'
+				'getOwnPropertyNames',
+				'keys'
 			].forEach((method) => assert.isFunction(object[method]));
-			assert.strictEqual(Object.keys(object).length, 3);
+			assert.strictEqual(Object.keys(object).length, 4);
 		}));
 	}
 });

--- a/tests/unit/object.ts
+++ b/tests/unit/object.ts
@@ -102,5 +102,25 @@ registerSuite({
 			bar: 1
 		};
 		assert.deepEqual(object.getOwnPropertyNames(o), [ 'bar' ]);
+	},
+
+	'.keys()'() {
+		const sym = Symbol('foo');
+		const o = {
+			[Symbol.iterator]() {
+				return 'foo';
+			},
+			[sym]: 'bar',
+			bar: 1
+		};
+
+		Object.defineProperty(o, 'baz', {
+			value: 'qat',
+			enumerable: false
+		});
+
+		assert.strictEqual((<any> o).baz, 'qat');
+		assert.strictEqual((<any> o)[sym], 'bar');
+		assert.deepEqual(object.keys(o), [ 'bar' ]);
 	}
 });


### PR DESCRIPTION
**Type:** bug

**Description:** 

This fixes an issue where when the `Symbol` shim is used, `Object.keys` and `for ... in` returns the symbol keys.

**Related Issue:** #46
