### PR TITLE
Fixing exported promise signature to better align with Promise.then

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -370,9 +370,9 @@ export default class Promise<T> implements Thenable<T> {
 		throw new Error();
 	}
 
-	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason: Error) => void): Promise<U>;
+	then<U>(onFulfilled?: (value: T) => U | Thenable<U> | undefined | null, onRejected?: (reason: Error) => void): Promise<U>;
 	/* istanbul ignore next */
-	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | null | undefined)) | null | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): Promise<U> {
+	then<U>(onFulfilled?: (value: T) => U | Thenable<U> | undefined | null, onRejected?: (reason: Error) => (U | Thenable<U>)): Promise<U> {
 		throw new Error();
 	}
 }

--- a/tests/unit/Promise.ts
+++ b/tests/unit/Promise.ts
@@ -408,7 +408,7 @@ export function addPromiseTests(suite: any, Promise: PromiseType) {
 
 		identity: function (this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).then(null, dfd.rejectOnError(function (value: Error) {
+			Promise.resolve(5).then(undefined, dfd.rejectOnError(function (value: Error) {
 				assert(false, 'Should not have resolved');
 			})).then(dfd.callback(function (value: number) {
 				assert.strictEqual(value, 5);


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** feature

**Description:** 

While looking into async/await stuff I noticed that our Promise export isn't quite compatible with Typescripts promise declaration.

**Related Issue:** None!

Please review this checklist before submitting your PR:

* [ ] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

