### PR TITLE
Adding Object.getOwnPropertyDescriptors shim, issue #28

### DIFF
--- a/tests/unit/object.ts
+++ b/tests/unit/object.ts
@@ -122,5 +122,44 @@ registerSuite({
 		assert.strictEqual((<any> o).baz, 'qat');
 		assert.strictEqual((<any> o)[sym], 'bar');
 		assert.deepEqual(object.keys(o), [ 'bar' ]);
+	},
+
+	'.getOwnPropertyDescriptors()'() {
+		const visibleSymbol = Symbol.for('foo');
+		const hiddenSymbol = Symbol.for('hidden');
+
+		const obj = {
+			prop1: 'value1',
+			get prop2() {
+				return 'value2';
+			},
+			set prop3(_: string) {
+			},
+			[visibleSymbol]: 'foo'
+		};
+
+		Object.defineProperty(obj, 'hidden', {
+			value: 'hidden',
+			enumerable: false
+		});
+
+		(<any> Object).defineProperty(obj, hiddenSymbol, {
+			value: 'test',
+			enumerable: false
+		});
+
+		let keys = object.getOwnPropertyDescriptors(obj);
+
+		assert.deepEqual(Object.keys(keys), [
+			'prop1',
+			'prop2',
+			'prop3',
+			'hidden'
+		]);
+
+		assert.deepEqual(object.getOwnPropertySymbols(obj), [
+			visibleSymbol,
+			hiddenSymbol
+		]);
 	}
 });

--- a/tests/unit/object.ts
+++ b/tests/unit/object.ts
@@ -150,14 +150,14 @@ registerSuite({
 
 		let keys = object.getOwnPropertyDescriptors(obj);
 
-		assert.deepEqual(Object.keys(keys), [
+		assert.sameMembers(Object.keys(keys), [
 			'prop1',
 			'prop2',
 			'prop3',
 			'hidden'
 		]);
 
-		assert.deepEqual(object.getOwnPropertySymbols(obj), [
+		assert.sameMembers(object.getOwnPropertySymbols(obj), [
 			visibleSymbol,
 			hiddenSymbol
 		]);


### PR DESCRIPTION
**Type:** feature

**Description:** 

Shim for `Object.getOwnPropertyDescriptors`, as described [here](https://github.com/tc39/proposal-object-getownpropertydescriptors).

Tested in Chrome, IE 10, IE 11, Node.

**Related Issue:** #28 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

