### PR TITLE
Fixing an issue with the promise shim

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -73,7 +73,7 @@ module Shim {
 
 				function processItem(index: number, item: (T | Thenable<T>)): void {
 					++total;
-					if (item instanceof Promise) {
+					if (isThenable(item)) {
 						// If an item Promise rejects, this Promise is immediately rejected with the item
 						// Promise's rejection error.
 						item.then(fulfill.bind(null, index), reject);

--- a/tests/unit/Promise.ts
+++ b/tests/unit/Promise.ts
@@ -126,6 +126,20 @@ export function addPromiseTests(suite: any, Promise: PromiseType) {
 			Promise.all(iterable).then(dfd.callback(function (value: number[]) {
 				assert.notStrictEqual(value, iterable);
 			}));
+		},
+
+		'non-promise thenables': function (this: any) {
+			let dfd = this.async();
+			let thenable = {
+				then(resolve: (_: string) => void) {
+					resolve('test');
+				}
+			};
+
+			Promise.all<any>([ 'hello', thenable ]).then((results: any[]) => {
+				assert.deepEqual(results, [ 'hello', 'test' ]);
+				dfd.resolve();
+			});
 		}
 	};
 


### PR DESCRIPTION
**Type:** bug

**Description:** 

A fix for a problem with `Promise.all`. The arguments accept a `Thenable`, but the actual code was checking specifically for a `Promise` type later on. This meant that you couldn't actually pass in a `Thenable` that wasn't a `Promise`.

Please review this checklist before submitting your PR:

* [ ] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

