### PR TITLE
Adding ES8 padStart/padEnd to string utils, issue #27

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -185,6 +185,44 @@ export namespace Shim {
 		return text.indexOf(search, position) !== -1;
 	}
 
+	export function padEnd(text: string, maxLength: number, fillString: string = ' '): string {
+		if (text === null || text === undefined) {
+			throw new TypeError('string.repeat requires a valid string.');
+		}
+
+		if (maxLength === null || maxLength === undefined || maxLength < 0 || maxLength === Infinity) {
+			throw new RangeError('string.padEnd requires a non-negative finite count.');
+		}
+
+		let strText = String(text);
+		const padding = maxLength - strText.length;
+
+		if (padding > 0) {
+			strText += repeat(fillString, Math.floor(padding / fillString.length)) + fillString.slice(0, padding % fillString.length);
+		}
+
+		return strText;
+	}
+
+	export function padStart(text: string, maxLength: number, fillString: string = ' '): string {
+		if (text === null || text === undefined) {
+			throw new TypeError('string.repeat requires a valid string.');
+		}
+
+		if (maxLength === null || maxLength === undefined || maxLength < 0 || maxLength === Infinity) {
+			throw new RangeError('string.padEnd requires a non-negative finite count.');
+		}
+
+		let strText = String(text);
+		const padding = maxLength - strText.length;
+
+		if (padding > 0) {
+			strText = repeat(fillString, Math.floor(padding / fillString.length)) + fillString.slice(0, padding % fillString.length) + strText;
+		}
+
+		return strText;
+	}
+
 	/* TODO: Provide an iterator for a string to mimic [Symbol.iterator]? */
 }
 
@@ -276,3 +314,29 @@ export const endsWith: (text: string, search: string, endPosition?: number) => b
 export const includes: (text: string, search: string, position?: number) => boolean = has('es6-string-includes')
 	? wrapNative((<any> String.prototype).includes)
 	: Shim.includes;
+
+/**
+ * Pads the beginning of a string with a fill string until the string is a certain length.
+ *
+ * @param text          The string to pad
+ * @param maxLength     The desired length of the string
+ * @param fillString    The string to be repeated (fully or partially) until text is the maximum length
+ *
+ * @return A string that is at least the maximum length specified, padded in the front if necessary.
+ */
+export const padStart: (text: string, maxLength: number, fillString?: string) => string = has('es6-string-padstart')
+	? wrapNative((<any> String.prototype).padStart)
+	: Shim.padStart;
+
+/**
+ * Pads the end of a string with a fill string until the string is a certain length.
+ *
+ * @param text          The string to pad
+ * @param maxLength     The desired length of the string
+ * @param fillString    The string to be repeated (fully or partially) until text is the maximum length
+ *
+ * @return A string that is at least the maximum length specified, padded at the end if necessary.
+ */
+export const padEnd: (text: string, maxLength: number, fillString?: string) => string = has('es6-string-padend')
+	? wrapNative((<any> String.prototype).padEnd)
+	: Shim.padEnd;

--- a/src/string.ts
+++ b/src/string.ts
@@ -190,8 +190,12 @@ export namespace Shim {
 			throw new TypeError('string.repeat requires a valid string.');
 		}
 
-		if (maxLength === null || maxLength === undefined || maxLength < 0 || maxLength === Infinity) {
+		if (maxLength === Infinity) {
 			throw new RangeError('string.padEnd requires a non-negative finite count.');
+		}
+
+		if (maxLength === null || maxLength === undefined || maxLength < 0) {
+			maxLength = 0;
 		}
 
 		let strText = String(text);
@@ -209,8 +213,12 @@ export namespace Shim {
 			throw new TypeError('string.repeat requires a valid string.');
 		}
 
-		if (maxLength === null || maxLength === undefined || maxLength < 0 || maxLength === Infinity) {
-			throw new RangeError('string.padEnd requires a non-negative finite count.');
+		if (maxLength === Infinity) {
+			throw new RangeError('string.padStart requires a non-negative finite count.');
+		}
+
+		if (maxLength === null || maxLength === undefined || maxLength < 0) {
+			maxLength = 0;
 		}
 
 		let strText = String(text);

--- a/src/support/has.ts
+++ b/src/support/has.ts
@@ -60,6 +60,8 @@ add('es6-string-repeat', 'repeat' in global.String.prototype);
 add('es6-string-startswith', 'startsWith' in global.String.prototype);
 add('es6-string-endswith', 'endsWith' in global.String.prototype);
 add('es6-string-includes', 'includes' in global.String.prototype);
+add('es6-string-padstart', 'padStart' in global.String.prototype);
+add('es6-string-padend', 'padEnd' in global.String.prototype);
 
 /* Math */
 

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -4,7 +4,7 @@ export const environments = [
 	{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
 	/* Issues with SauceLabs and Edge ;-( */
 	// { browserName: 'microsoftedge', platform: 'Windows 10' },
-	{ browserName: 'firefox', version: '43', platform: 'Windows 10' },
+	{ browserName: 'firefox', version: '50', platform: 'Windows 7' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	/* Issues with SauceLabs and Safari ;-( */
 	// { browserName: 'safari', version: '9', platform: 'OS X 10.11' },

--- a/tests/unit/string.ts
+++ b/tests/unit/string.ts
@@ -347,5 +347,79 @@ registerSuite({
 			assert.isTrue(stringUtil.startsWith('\xA2fa\uDA04', 'fa\uDA04', 1));
 			assert.isTrue(stringUtil.startsWith('\xA2fa\uDA04', '\uDA04', 3));
 		}
+	},
+
+	'.padEnd()': {
+		'null/undefined string'() {
+			assert.throws(() => {
+				stringUtil.padEnd(<any> null, 12);
+			});
+
+			assert.throws(() => {
+				stringUtil.padEnd(<any> undefined, 12);
+			});
+		},
+
+		'null/undefined/invalid length'() {
+			assert.throws(() => {
+				stringUtil.padEnd('', <any> null);
+			});
+
+			assert.throws(() => {
+				stringUtil.padEnd('', <any> undefined);
+			});
+
+			assert.throws(() => {
+				stringUtil.padEnd('', -1);
+			});
+
+			assert.throws(() => {
+				stringUtil.padEnd('', Infinity);
+			});
+		},
+
+		'padEnd()'() {
+			assert.equal(stringUtil.padEnd('', 10), '          ');
+			assert.equal(stringUtil.padEnd('test', 5), 'test ');
+			assert.equal(stringUtil.padEnd('test', 10, 'test'), 'testtestte');
+			assert.equal(stringUtil.padEnd('test', 3, 'padding'), 'test');
+		}
+	},
+
+	'.padStart()': {
+		'null/undefined string'() {
+			assert.throws(() => {
+				stringUtil.padStart(<any> null, 12);
+			});
+
+			assert.throws(() => {
+				stringUtil.padStart(<any> undefined, 12);
+			});
+		},
+
+		'null/undefined/invalid length'() {
+			assert.throws(() => {
+				stringUtil.padStart('', <any> null);
+			});
+
+			assert.throws(() => {
+				stringUtil.padStart('', <any> undefined);
+			});
+
+			assert.throws(() => {
+				stringUtil.padStart('', -1);
+			});
+
+			assert.throws(() => {
+				stringUtil.padStart('', Infinity);
+			});
+		},
+
+		'padStart()'() {
+			assert.equal(stringUtil.padStart('', 10), '          ');
+			assert.equal(stringUtil.padStart('test', 5), ' test');
+			assert.equal(stringUtil.padStart('test', 10, 'test'), 'testtetest');
+			assert.equal(stringUtil.padStart('test', 3, 'padding'), 'test');
+		}
 	}
 });

--- a/tests/unit/string.ts
+++ b/tests/unit/string.ts
@@ -361,17 +361,9 @@ registerSuite({
 		},
 
 		'null/undefined/invalid length'() {
-			assert.throws(() => {
-				stringUtil.padEnd('', <any> null);
-			});
-
-			assert.throws(() => {
-				stringUtil.padEnd('', <any> undefined);
-			});
-
-			assert.throws(() => {
-				stringUtil.padEnd('', -1);
-			});
+			assert.equal(stringUtil.padEnd('test', <any> null), 'test');
+			assert.equal(stringUtil.padEnd('test', <any> undefined), 'test');
+			assert.equal(stringUtil.padEnd('test', -1), 'test');
 
 			assert.throws(() => {
 				stringUtil.padEnd('', Infinity);
@@ -398,17 +390,9 @@ registerSuite({
 		},
 
 		'null/undefined/invalid length'() {
-			assert.throws(() => {
-				stringUtil.padStart('', <any> null);
-			});
-
-			assert.throws(() => {
-				stringUtil.padStart('', <any> undefined);
-			});
-
-			assert.throws(() => {
-				stringUtil.padStart('', -1);
-			});
+			assert.equal(stringUtil.padStart('test', <any> null), 'test');
+			assert.equal(stringUtil.padStart('test', <any> undefined), 'test');
+			assert.equal(stringUtil.padStart('test', -1), 'test');
 
 			assert.throws(() => {
 				stringUtil.padStart('', Infinity);


### PR DESCRIPTION
**Type:** feature

**Description:** 

Adding ES 8 `padStart` and `padEnd` to string shim.

**Related Issue:** #27 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

