### PR TITLE
Adding readonly modifier to readonly properties, issue #7

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -10,8 +10,8 @@ export namespace Shim {
 	 * An implementation analogous to the Map specification in ES2015.
 	 */
 	export class Map<K, V> {
-		protected _keys: K[] = [];
-		protected _values: V[] = [];
+		protected readonly _keys: K[] = [];
+		protected readonly _values: V[] = [];
 
 		/**
 		 * An alternative to Array.prototype.indexOf using Object.is

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -6,7 +6,7 @@ import './Symbol';
 
 export namespace Shim {
 	export class Set<T> {
-		private _setData: T[] = [];
+		private readonly _setData: T[] = [];
 
 		constructor(iterable?: ArrayLike<T> | Iterable<T>) {
 			if (iterable) {

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -25,8 +25,8 @@ module Shim {
 	})();
 
 	export class WeakMap<K, V> {
-		private _name: string;
-		private _frozenEntries: Entry<K, V>[];
+		private readonly _name: string;
+		private readonly _frozenEntries: Entry<K, V>[];
 
 		constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {
 			Object.defineProperty(this, '_name', {

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -3,8 +3,8 @@ import { HIGH_SURROGATE_MIN, HIGH_SURROGATE_MAX } from './string';
 import './Symbol';
 
 export interface IteratorResult<T> {
-	done: boolean;
-	value: T;
+	readonly done: boolean;
+	readonly value: T;
 }
 
 export interface Iterator<T> {

--- a/src/native/Map.ts
+++ b/src/native/Map.ts
@@ -7,7 +7,7 @@ export interface Map<K, V> {
 	get(key: K): V | undefined;
 	has(key: K): boolean;
 	set(key: K, value?: V): this;
-	size: number;
+	readonly size: number;
 }
 
 export interface MapConstructor {

--- a/src/native/Set.ts
+++ b/src/native/Set.ts
@@ -6,7 +6,7 @@ export interface Set<T> {
 	delete(value: T): boolean;
 	forEach(callbackfn: (value: T, index: T, set: Set<T>) => void, thisArg?: any): void;
 	has(value: T): boolean;
-	size: number;
+	readonly size: number;
 }
 
 export interface SetConstructor {

--- a/src/native/iterator.ts
+++ b/src/native/iterator.ts
@@ -1,6 +1,6 @@
 export interface IteratorResult<T> {
-	done: boolean;
-	value?: T;
+	readonly done: boolean;
+	readonly value?: T;
 }
 
 export interface Iterator<T> {

--- a/src/support/queue.ts
+++ b/src/support/queue.ts
@@ -4,12 +4,12 @@ import has from './has';
 
 export interface QueueItem {
 	isActive: boolean;
-	callback: (...args: any[]) => any;
+	readonly callback: (...args: any[]) => any;
 }
 
 interface PostMessageEvent extends Event {
-	source: any;
-	data: string;
+	readonly source: any;
+	readonly data: string;
 }
 
 /**


### PR DESCRIPTION
**Type:** feature

**Description:** 

Went through and added the `readonly` TS 2 modifier to...

1) private instance variables that are only assigned to at initialization time / in the constructor
2) properties defined in an interface that shouldn't be changed after they are defined (think iterator results).

`get` variables are implicitly read only so don't need (and can't have) the modifier.

**Related Issue:** #7 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged

