### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dojo-shim
+# @dojo/shim
 
 [![Build Status](https://travis-ci.org/dojo/shim.svg?branch=master)](https://travis-ci.org/dojo/shim)
 [![codecov](https://codecov.io/gh/dojo/shim/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/shim)
-[![npm version](https://badge.fury.io/js/dojo-shim.svg)](http://badge.fury.io/js/dojo-shim)
+[![npm version](https://badge.fury.io/js/@dojo/shim.svg)](http://badge.fury.io/js/@dojo/shim)
 
 This package provides functional shims for ECMAScript.
 
@@ -23,12 +23,12 @@ TODO: Add sections on features of this package
 
 #### Map
 
-The [`dojo-shim/Map` class](docs/Map.md) is an implementation of the ES2015 Map specification
+The [`@dojo/shim/Map` class](docs/Map.md) is an implementation of the ES2015 Map specification
 without iterators for use in older browsers.
 
 #### WeakMap
 
-The `dojo-shim/WeakMap` class is an implementation of the ES2015 WeakMap specification
+The `@dojo/shim/WeakMap` class is an implementation of the ES2015 WeakMap specification
 without iterators for use in older browsers. The main difference between WeakMap and Map
 is that WeakMap's keys can only be objects and that the store has a weak reference
 to the key/value pair. This allows for the garbage collector to remove pairs.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/node": "~6.0.49",
-    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "~1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.22",
     "intern": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-shim",
+  "name": "@dojo/shim",
   "version": "2.0.0-pre",
   "description": "Modules that provide modular fills of ES6+ functionality",
   "homepage": "http://dojotoolkit.org",
@@ -18,14 +18,14 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-has": ">=2.0.0-alpha.6"
+    "@dojo/has": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/node": "~6.0.49",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/loader": "2.0.0-beta.8",
     "grunt": "~1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.22",
     "intern": "^3.4.1",

--- a/src/support/has.ts
+++ b/src/support/has.ts
@@ -1,9 +1,9 @@
 import global from './global';
-import has from 'dojo-has/has';
-import { add } from 'dojo-has/has';
+import has from '@dojo/has/has';
+import { add } from '@dojo/has/has';
 
 export default has;
-export * from 'dojo-has/has';
+export * from '@dojo/has/has';
 
 /* ECMAScript 6 and 7 Features */
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-shim'
+	name: '@dojo/shim'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -45,8 +45,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
@@ -57,7 +57,7 @@ export const loaderOptions = {
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
-		{ name: 'dojo-has', location: 'node_modules/dojo-has' }
+		{ name: '@dojo/has', location: 'node_modules/@dojo/has' }
 	]
 };
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -57,7 +57,7 @@ export const loaderOptions = {
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
-		{ name: '@dojo/has', location: 'node_modules/@dojo/has' }
+		{ name: '@dojo', location: 'node_modules/@dojo' }
 	]
 };
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129