### PR TITLE
Fixing type signatures for Promise.all

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -316,11 +316,8 @@ export default class Promise<T> implements Thenable<T> {
 	 *     value.bar === 'bar'; // true
 	 * });
 	 */
-	static all<T>(iterable: (T | Thenable<T>)[]): Promise<T[]>;
-	static all<T>(iterable: T | Thenable<T>): Promise<T[]>;
-	static all<T>(iterable: Iterable<(T | Thenable<T>)>): Promise<T[]>;
 	/* istanbul ignore next */
-	static all<T>(iterable: T | Thenable<T> | Iterable<(T | Thenable<T>)>): Promise<T[]> {
+	static all<T>(iterable: (T | Thenable<T>)[] | Iterable<(T | Thenable<T>)>): Promise<T[]> {
 		throw new Error();
 	};
 
@@ -420,9 +417,7 @@ declare global {
 		 *     value.bar === 'bar'; // true
 		 * });
 		 */
-		static all<T>(iterable: (T | Thenable<T>)[]): Promise<T[]>;
-		static all<T>(iterable: T | Thenable<T>): Promise<T[]>;
-		static all<T>(iterable: Iterable<(T | Thenable<T>)>): Promise<T[]>;
+		static all<T>(iterable: (T | Thenable<T>)[] | Iterable<(T | Thenable<T>)>): Promise<T[]>;
 
 		/**
 		 * Converts an iterable object containing promises into a single promise that resolves or rejects as soon as one of


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Fixing signature for `Promise.all`. The method takes `(T | Thenable<T>)[] | Iterable<T | Thenable<T>>` but you couldn't actually pass it that. You could either pass a `(T | Thenable<T>)[]` or a `Iterable<T | Thenable<T>>`, but not a union type of the two. This PR fixes that :)
