### PR TITLE
Add detection for buggy MutationObserver implementations

### DIFF
--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -5,7 +5,10 @@ export const environments = [
 	/* Issues with SauceLabs and Edge ;-( */
 	// { browserName: 'microsoftedge', platform: 'Windows 10' },
 	{ browserName: 'firefox', version: '50', platform: 'Windows 7' },
-	{ browserName: 'chrome', platform: 'Windows 10' }
+	{ browserName: 'chrome', platform: 'Windows 10' },
+	// Chrome 31 has no Promise and a non-buggy MutationObserver
+	// so we can test our MutationObserver queue implementation
+	{ browserName: 'chrome', version: '31', platform: 'Windows 10' }
 	/* Issues with SauceLabs and Safari ;-( */
 	// { browserName: 'safari', version: '9', platform: 'OS X 10.11' },
 	// Issues with android running on saucelabs

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -23,6 +23,9 @@ export const environments = [
 	{ browserName: 'edge' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
+	// Chrome 31 has no Promise and a non-buggy MutationObserver
+	// so we can test our MutationObserver queue implementation
+	{ browserName: 'chrome', version: '31', platform: 'WINDOWS' },
 	// Issue with iphone 9.1 compatability, commented out for move to
 	// browserstack and issue raised.https://github.com/dojo/shim/issues/96
 	// { browserName: 'iPhone', version: '9.1' },


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

IE11 has an unreliable MutationObserver implementation where `setProperty()` does not generate a mutation event, observers can crash, and the queue does not drain reliably. The feature test was adapted from https://gist.github.com/t10ko/4aceb8c71681fdb275e33efe5e576b14. In lieu of added unit tests, Chrome 31 was added as a test target in order to test the case where no native `Promise` implementation exists, but a `MutationObserver` implementation exists.

Resolves #103
