### PR TITLE
Removing forOf in favor of downlevelIteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
+    "intersection-observer": "^0.4.0",
+    "pepjs": "^0.4.2",
     "tslib": "^1.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "intern": "^3.4.1",
     "istanbul": "^0.4.3",
     "typescript": "~2.4.1"
+  },
+  "dependencies": {
+    "tslib": "^1.7.1"
   }
 }

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1,5 +1,5 @@
-import { forOf, Iterable, IterableIterator, ShimIterator } from './iterator';
 import global from './global';
+import { Iterable, IterableIterator, ShimIterator } from './iterator';
 import { is as objectIs } from './object';
 import has from './support/has';
 import './Symbol';
@@ -146,9 +146,9 @@ if (!has('es6-map')) {
 
 		constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {
 			if (iterable) {
-				forOf(iterable, (value: [K, V]) => {
+				for (const value of iterable) {
 					this.set(value[0], value[1]);
-				});
+				}
 			}
 		}
 

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { Iterable, forOf, isIterable, isArrayLike } from './iterator';
+import { Iterable, isIterable, isArrayLike } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -431,9 +431,9 @@ if (!has('es-observable')) {
 				}
 
 				return new constructor((observer: SubscriptionObserver<U>) => {
-					forOf(items, (o: any) => {
+					for (const o of items) {
 						observer.next(o);
-					});
+					}
 					observer.complete();
 				});
 			}
@@ -483,9 +483,9 @@ if (!has('es-observable')) {
 				}
 				else if (isIterable(item) || isArrayLike(item)) {
 					return new constructor((observer: SubscriptionObserver<U>) => {
-						forOf(item, (o: any) => {
+						for (const o of item) {
 							observer.next(o);
-						});
+						}
 						observer.complete();
 					});
 				}

--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -1,9 +1,9 @@
-import { Thenable } from './interfaces';
 import global from './global';
-import { queueMicroTask } from './support/queue';
-import { forOf, Iterable } from './iterator';
-import './Symbol';
+import { Thenable } from './interfaces';
+import { Iterable } from './iterator';
 import has from './support/has';
+import { queueMicroTask } from './support/queue';
+import './Symbol';
 
 /**
  * Executor is the interface for functions used to initialize a Promise.
@@ -65,10 +65,10 @@ if (!has('es6-promise')) {
 				}
 
 				let i = 0;
-				forOf(iterable, function (value: any) {
+				for (const value of iterable) {
 					processItem(i, value);
 					i++;
-				});
+				}
 				populating = false;
 
 				finish();
@@ -77,7 +77,7 @@ if (!has('es6-promise')) {
 
 		static race<T>(iterable: Iterable<(T | PromiseLike<T>)> | (T | PromiseLike<T>)[]): Promise<T[]> {
 			return new this(function (resolve: (value?: any) => void, reject) {
-				forOf(iterable, function (item: T | PromiseLike<T>) {
+				for (const item of iterable) {
 					if (item instanceof Promise) {
 						// If a Promise item rejects, this Promise is immediately rejected with the item
 						// Promise's rejection error.
@@ -86,7 +86,7 @@ if (!has('es6-promise')) {
 					else {
 						Promise.resolve(item).then(resolve);
 					}
-				});
+				}
 			});
 		}
 

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { forOf, IterableIterator, Iterable, ShimIterator } from './iterator';
+import { IterableIterator, Iterable, ShimIterator } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -110,7 +110,9 @@ if (!has('es6-set')) {
 
 		constructor(iterable?: ArrayLike<T> | Iterable<T>) {
 			if (iterable) {
-				forOf(iterable, (value) => this.add(value));
+				for (const value of iterable) {
+					this.add(value);
+				}
 			}
 		};
 

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { forOf, Iterable } from './iterator';
+import { Iterable } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -103,7 +103,9 @@ if (!has('es6-weakmap')) {
 			this._frozenEntries = [];
 
 			if (iterable) {
-				forOf(iterable, ([ key, value ]: [K, V]) => this.set(key, value));
+				for (const [key, value] of iterable) {
+					this.set(key, value);
+				}
 			}
 		}
 

--- a/src/array.ts
+++ b/src/array.ts
@@ -193,7 +193,7 @@ else {
 		// Support extension
 		const array: any[] = (typeof Constructor === 'function') ? <any[]> Object(new Constructor(length)) : new Array(length);
 
-		if (!isArrayLike(arrayLike) && !isIterable(arrayLike)) {
+		if (!isArrayLike(arrayLike) && !isIterable(arrayLike) || (isArrayLike(arrayLike) && isNaN(arrayLike.length))) {
 			return array;
 		}
 

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { forOf, isArrayLike, isIterable, Iterable } from './iterator';
+import { isArrayLike, isIterable, Iterable } from './iterator';
 import { MAX_SAFE_INTEGER } from './number';
 import has from './support/has';
 import { wrapNative } from './support/util';
@@ -198,10 +198,10 @@ else {
 		}
 
 		let i = 0;
-		forOf(arrayLike, function (value): void {
+		for (const value of arrayLike) {
 			array[i] = mapFunction ? mapFunction(value, i) : value;
 			i++;
-		});
+		}
 
 		if ((<any> arrayLike).length !== undefined) {
 			array.length = length;

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -1,4 +1,3 @@
-import { HIGH_SURROGATE_MIN, HIGH_SURROGATE_MAX } from './string';
 import './Symbol';
 
 export interface IteratorResult<T> {
@@ -79,76 +78,4 @@ export function isIterable(value: any): value is Iterable<any> {
  */
 export function isArrayLike(value: any): value is ArrayLike<any> {
 	return value && typeof value.length === 'number';
-}
-
-/**
- * Returns the iterator for an object
- *
- * @param iterable The iterable object to return the iterator for
- */
-export function get<T>(iterable: Iterable<T> | ArrayLike<T>): Iterator<T> | undefined {
-	if (isIterable(iterable)) {
-		return iterable[Symbol.iterator]();
-	}
-	else if (isArrayLike(iterable)) {
-		return new ShimIterator(iterable);
-	}
-};
-
-export interface ForOfCallback<T> {
-	/**
-	 * A callback function for a forOf() iteration
-	 *
-	 * @param value The current value
-	 * @param object The object being iterated over
-	 * @param doBreak A function, if called, will stop the iteration
-	 */
-	(value: T, object: Iterable<T> | ArrayLike<T> | string, doBreak: () => void): void;
-}
-
-/**
- * Shims the functionality of `for ... of` blocks
- *
- * @param iterable The object the provides an interator interface
- * @param callback The callback which will be called for each item of the iterable
- * @param thisArg Optional scope to pass the callback
- */
-export function forOf<T>(iterable: Iterable<T> | ArrayLike<T> | string, callback: ForOfCallback<T>, thisArg?: any): void {
-	let broken = false;
-
-	function doBreak() {
-		broken = true;
-	}
-
-	/* We need to handle iteration of double byte strings properly */
-	if (isArrayLike(iterable) && typeof iterable === 'string') {
-		const l = iterable.length;
-		for (let i = 0; i < l; ++i) {
-			let char = iterable[i];
-			if ((i + 1) < l) {
-				const code = char.charCodeAt(0);
-				if ((code >= HIGH_SURROGATE_MIN) && (code <= HIGH_SURROGATE_MAX)) {
-					char += iterable[++i];
-				}
-			}
-			callback.call(thisArg, char, iterable, doBreak);
-			if (broken) {
-				return;
-			}
-		}
-	}
-	else {
-		const iterator = get(iterable);
-		if (iterator) {
-			let result = iterator.next();
-
-			while (!result.done) {
-				callback.call(thisArg, result.value, iterable, doBreak);
-				if (broken) {
-					return;
-				}
-				result = iterator.next();
-			}
-		}
-	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import './support/helpers';
+
 import * as array from './array';
 import * as iterator from './iterator';
 import Map from './Map';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,25 +1,37 @@
-import './support/helpers';
+// import TS helpers
+import './tslib';
 
-import * as array from './array';
-import * as iterator from './iterator';
-import Map from './Map';
-import * as math from './math';
-import * as number from './number';
-import * as object from './object';
-import Set from './Set';
-import * as string from './string';
-import Symbol from './Symbol';
-import WeakMap from './WeakMap';
+// import our polyfills
+`!has('es6-promise')`;
+import './Promise';
 
-export {
-	array,
-	iterator,
-	Map,
-	math,
-	number,
-	object,
-	Set,
-	string,
-	Symbol,
-	WeakMap
-};
+`!has('es6-symbol')`;
+import './Symbol';
+
+`!has('es6-map')`;
+import './Map';
+
+`!has('es6-weakmap')`;
+import './WeakMap';
+
+`!has('es6-set')`;
+import './Set';
+
+`!has('es6-math')`;
+import './math';
+
+`!has('es6-array', 'es6-array-fill')`;
+import './array';
+
+`!has('es6-string', 'es6-string-raw')`;
+import './string';
+
+`!has('es6-object')`;
+import './object';
+
+// import 3rd party polyfills
+`!has('pointer-events')`;
+import 'pepjs';
+
+`!has('intersection-observer')`;
+import 'intersection-observer';

--- a/src/support/helpers.ts
+++ b/src/support/helpers.ts
@@ -1,0 +1,45 @@
+import global from '../global';
+
+/**
+ * Provide any overrides and then load the TypeScript helpers.
+ */
+global.__values = function (o: any) {
+	let m = typeof Symbol === 'function' && o[ Symbol.iterator ], i = 0;
+	if (m) {
+		return m.call(o);
+	}
+
+	if (typeof o === 'string') {
+		const l = o.length;
+
+		return {
+			next: function () {
+				if (i >= l) {
+					return { done: true };
+				}
+
+				let char = o[ i++ ];
+				if (i < l) {
+					let code = char.charCodeAt(0);
+					if ((code >= 0xD800) && (code <= 0xDBFF)) {
+						char += o[ i++ ];
+					}
+				}
+
+				return { value: char, done: false };
+			}
+		};
+	}
+
+	return {
+		next: function () {
+			if (o && i >= o.length) {
+				o = void 0;
+			}
+			return { value: o && o[ i++ ], done: !o };
+		}
+	};
+};
+
+// load typescript helpers
+import 'tslib';

--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -1,4 +1,4 @@
-import global from '../global';
+import global from './global';
 
 /**
  * Provide any overrides and then load the TypeScript helpers.

--- a/tests/unit/Map.ts
+++ b/tests/unit/Map.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { forOf, isIterable, IterableIterator, ShimIterator } from '../../src/iterator';
+import { isIterable, IterableIterator, ShimIterator } from '../../src/iterator';
 import Map from '../../src/Map';
 
 let map: Map<any, any>;
@@ -94,11 +94,11 @@ registerSuite({
 		assert.isTrue(isIterable(entries), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(entries, function (value: [ number, any ]): void {
+		for (const value of entries) {
 			assert.strictEqual(value[0], mapArgs[i][0]);
 			assert.strictEqual(value[1], mapArgs[i][1]);
 			i++;
-		});
+		}
 	},
 
 	forEach: {
@@ -182,10 +182,10 @@ registerSuite({
 		assert.isTrue(isIterable(keys), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(keys, function (value: number): void {
+		for (const value of keys) {
 			assert.strictEqual(value, mapArgs[i][0]);
 			i++;
-		});
+		}
 	},
 
 	set: {
@@ -266,9 +266,9 @@ registerSuite({
 		assert.isTrue(isIterable(values), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(values, function (value: any): void {
+		for (const value of values) {
 			assert.strictEqual(value, mapArgs[i][1]);
 			i++;
-		});
+		}
 	}
 });

--- a/tests/unit/Set.ts
+++ b/tests/unit/Set.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Set from '../../src/Set';
-import { forOf, ShimIterator } from '../../src/iterator';
+import { ShimIterator } from '../../src/iterator';
 
 registerSuite({
 	name: 'Set',
@@ -51,7 +51,9 @@ registerSuite({
 		const source = [1, 2, 3];
 		const set = new Set(source);
 		const results: number[] = [];
-		forOf(set, (value) => results.push(value));
+		for (const value of set) {
+			results.push(value);
+		}
 		assert.deepEqual(results, source, 'results should match source');
 	},
 
@@ -59,7 +61,9 @@ registerSuite({
 		const source = [1, 2, 3];
 		const set = new Set(source);
 		const results: number[] = [];
-		forOf(set.values(), (value) => results.push(value));
+		for (const value of set.values()) {
+			results.push(value);
+		}
 		assert.deepEqual(results, source, 'results should match source');
 	},
 
@@ -67,14 +71,18 @@ registerSuite({
 		const source = [1, 2, 3];
 		const set = new Set(source);
 		const results: number[] = [];
-		forOf(set.keys(), (value) => results.push(value));
+		for (const value of set.keys()) {
+			results.push(value);
+		}
 		assert.deepEqual(results, source, 'results should match source');
 	},
 
 	'.entries()'() {
 		const set = new Set([1, 2, 3]);
 		const results: [number, number][] = [];
-		forOf(set.entries(), (value) => results.push(value));
+		for (const value of set.entries()) {
+			results.push(value);
+		}
 		assert.deepEqual(results, [[1, 1], [2, 2], [3, 3]], 'results should match expected');
 	},
 

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,3 +1,6 @@
+// we need to include the TS helpers before we load the rest of the tests
+import '../../src/support/helpers';
+
 import './support/decorators';
 import './support/has';
 import './support/queue';

--- a/tests/unit/iterator.ts
+++ b/tests/unit/iterator.ts
@@ -1,21 +1,21 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { forOf, get, ShimIterator } from '../../src/iterator';
+import { ShimIterator } from '../../src/iterator';
 import '../../src/Symbol';
 
 registerSuite({
 	name: 'iterator',
 
-	'forOf': {
+	'for of': {
 
 		'strings'() {
 			const str = 'abcdefg';
 			const results: string[] = [];
 			const expected = [ 'a', 'b', 'c', 'd', 'e', 'f', 'g' ];
 
-			forOf(str, (value) => {
+			for (const value of str) {
 				results.push(value);
-			});
+			}
 
 			assert.deepEqual(results, expected);
 		},
@@ -25,9 +25,9 @@ registerSuite({
 			const results: string[] = [];
 			const expected = [ '¯', '\\', '_', '(', 'ツ', ')', '_', '/', '¯' ];
 
-			forOf(str, (value) => {
+			for (const value of str) {
 				results.push(value);
-			});
+			}
 
 			assert.deepEqual(results, expected);
 		},
@@ -37,9 +37,9 @@ registerSuite({
 			const results: string[] = [];
 			const expected = [ '\uD801\uDC00' ];
 
-			forOf(str, (value) => {
+			for (const value of str) {
 				results.push(value);
-			});
+			}
 
 			assert.deepEqual(results, expected);
 		},
@@ -48,9 +48,9 @@ registerSuite({
 			const array: any[] = [ 'foo', 'bar', {}, 1, [ 'qat', 2 ] ];
 			const results: any[] = [];
 
-			forOf(array, (value) => {
+			for (const value of array) {
 				results.push(value);
-			});
+			}
 
 			assert.deepEqual(results, array);
 			assert.notStrictEqual(results, array);
@@ -61,7 +61,7 @@ registerSuite({
 			const iterable = {
 				[Symbol.iterator]() {
 					return {
-						next(): {value: number | undefined, done: boolean}  {
+						next(): { value: number | undefined, done: boolean } {
 							counter++;
 							if (counter < 5) {
 								return {
@@ -79,132 +79,12 @@ registerSuite({
 			const results: (undefined | number)[] = [];
 			const expected = [ 1, 2, 3, 4 ];
 
-			forOf(iterable, (value) => {
+			for (const value of iterable) {
 				results.push(value);
-			});
-
-			assert.deepEqual(results, expected);
-		},
-
-		'scoping'() {
-			const array = [ 'a', 'b' ];
-			const scope = { foo: 'bar' };
-
-			forOf(array, function (this: any, value: any, obj: any) {
-				assert.strictEqual(this, scope);
-				assert.strictEqual(obj, array);
-			}, scope);
-		},
-
-		'doBreak': {
-			strings() {
-				const str = 'abcdefg';
-				let counter = 0;
-				const results: string[] = [];
-				const expected = [ 'a', 'b', 'c' ];
-
-				forOf(str, (value, str, doBreak) => {
-					results.push(value);
-					counter++;
-					if (counter >= 3) {
-						doBreak();
-					}
-				});
-
-				assert.deepEqual(results, expected);
-			},
-			iterable() {
-				let counter = 0;
-				const iterable = {
-					[Symbol.iterator]() {
-						return {
-							next(): {value: number | undefined, done: boolean} {
-								counter++;
-								if (counter < 5) {
-									return {
-										value: counter,
-										done: false
-									};
-								}
-								else {
-									return { done: true, value: undefined };
-								}
-							}
-						};
-					}
-				};
-				const results: (undefined | number)[] = [];
-				const expected = [ 1, 2 ];
-
-				forOf(iterable, (value, obj, doBreak) => {
-					results.push(value);
-					if (value === 2) {
-						doBreak();
-					}
-				});
-
-				assert.deepEqual(results, expected);
 			}
-		}
 
-	},
-
-	'get': {
-
-		'iterable'() {
-			let counter = 0;
-			const iterable = {
-				[Symbol.iterator]() {
-					return {
-						next(): {value: number | undefined, done: boolean} {
-							counter++;
-							if (counter < 5) {
-								return {
-									value: counter,
-									done: false
-								};
-							}
-							else {
-								return { done: true, value: undefined };
-							}
-						}
-					};
-				}
-			};
-			const results: (undefined | number)[] = [];
-			const expected = [ 1, 2, 3, 4 ];
-			const iterator = get(iterable);
-			if (iterator) {
-				let result = iterator.next();
-				while (!result.done) {
-					results.push(result.value);
-					result = iterator.next();
-				}
-			}
-			assert.deepEqual(results, expected);
-		},
-
-		'arrayLike'() {
-			const obj: { [idx: number]: number; length: number; } = {
-				0: 1,
-				1: 2,
-				2: 3,
-				3: 4,
-				length: 4
-			};
-			const results: number[] = [];
-			const expected = [ 1, 2, 3, 4 ];
-			const iterator = get(obj);
-			if (iterator) {
-				let result = iterator.next();
-				while (!result.done) {
-					results.push(result.value);
-					result = iterator.next();
-				}
-			}
 			assert.deepEqual(results, expected);
 		}
-
 	},
 
 	'class ShimIterator': {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"version": "2.0.2",
 	"compilerOptions": {
 		"declaration": false,
+		"downlevelIteration": true,
 		"experimentalDecorators": true,
 		"module": "umd",
 		"lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
 		"moduleResolution": "node",
 		"strictNullChecks": true,
 		"noImplicitThis": true,
+		"noEmitHelpers": true,
 		"types": [ "intern" ]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Using the `downlevelIteration` flag to get rid of the `forOf` function and just use the `for...of` construct instead! Note that this is a breaking change for anything that used `forOf`.

Resolves #109
