### PR TITLE
Add dist to CI and default to declaration true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
 - grunt intern:browserstack --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
+- grunt dist
 - grunt doc
 notifications:
   slack:

--- a/tests/unit/Promise.ts
+++ b/tests/unit/Promise.ts
@@ -5,7 +5,7 @@ import Promise from '../../src/Promise';
 import { ShimIterator } from '../../src/iterator';
 import '../../src/Symbol';
 
-type TypeUnderTest = typeof Promise;
+export type TypeUnderTest = typeof Promise;
 
 /* tslint:disable-next-line:variable-name */
 export function addPromiseTests(suite: any, Promise: TypeUnderTest) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"version": "2.0.2",
 	"compilerOptions": {
-		"declaration": false,
+		"declaration": true,
 		"experimentalDecorators": true,
 		"module": "umd",
 		"lib": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Trying to improve the robustness of our distributions by catching distribution errors earlier.  This adds `grunt dist` to the CI process and sets `--declaration` to even the dev build process.

Refs: dojo/meta#200