### PR TITLE
Ignoring coverage files from intern4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage-unmapped.json
 npm-debug.log
 /_apidoc
 deploy_key
+coverage/
+coverage-final.lcov


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding intern4 code coverage files to the `.gitignore`.
