### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:browserstack
+- grunt intern:browserstack --test-reporter
 - grunt uploadCoverage
 - grunt dist
 - grunt doc

--- a/intern.json
+++ b/intern.json
@@ -19,20 +19,17 @@
 					{ "name": "src", "location": "_build/src" },
 					{ "name": "tests", "location": "_build/tests" },
 					{ "name": "@dojo", "location": "node_modules/@dojo" },
-					{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" },
-					{ "name": "grunt-dojo2", "location": "node_modules/grunt-dojo2"}
+					{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" }
 				]
 			}
 		}
 	},
 
-	"configs": {
-		"coverage": {
-			"coverage": [
-				"./_build/src/**/*.js"
-			]
-		},
+	"coverage": [
+		"./_build/src/**/*.js"
+	],
 
+	"configs": {
 		"remoteCapabilities": {
 			"capabilities": {
 				"project": "Dojo 2",
@@ -42,7 +39,7 @@
 		},
 
 		"browserstack": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "browserstack",
 			"capabilities+": {
@@ -60,7 +57,7 @@
 		},
 
 		"local": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "selenium",
 			"tunnelOptions": {
@@ -74,7 +71,7 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},

--- a/intern.json
+++ b/intern.json
@@ -1,4 +1,11 @@
 {
+	"capabilities": {
+		"project": "Dojo 2",
+		"name": "@dojo/shim",
+		"fixSessionCapabilities": false,
+		"browserstack.debug": false
+	},
+
 	"environments": [
 		{ "browserName": "node" }
 	],
@@ -30,21 +37,8 @@
 	],
 
 	"configs": {
-		"remoteCapabilities": {
-			"capabilities": {
-				"project": "Dojo 2",
-				"name": "@dojo/shim",
-				"fixSessionCapabilities": false
-			}
-		},
-
 		"browserstack": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "browserstack",
-			"capabilities+": {
-				"browserstack.debug": false
-			},
 
 			"environments+": [
 				{ "browserName": "internet explorer", "version": "11" },
@@ -57,8 +51,6 @@
 		},
 
 		"local": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "selenium",
 			"tunnelOptions": {
 				"hostname": "localhost",
@@ -71,8 +63,6 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},
 


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this can land.