### PR TITLE
Replacing noEmitHelpers with importHelpers

### DIFF
--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -41,6 +41,3 @@ import * as tslib from 'tslib';
 		}
 	};
 };
-
-// load typescript helpers
-import 'tslib';

--- a/tests/unit/support/queue.ts
+++ b/tests/unit/support/queue.ts
@@ -182,14 +182,11 @@ registerSuite('queue functions', {
 self.addEventListener('message', function (event) {
 	if(event.data.baseUrl) {
 		var baseUrl = event.data.baseUrl;
-		importScripts(baseUrl + '/node_modules/@dojo/loader/loader.js');
+		importScripts(baseUrl + '/_build/src/util/amd.js', baseUrl + '/node_modules/@dojo/loader/loader.js');
 
-		require.config({
-			baseUrl: baseUrl,
-			packages: [
-				{ name: '@dojo', location: 'node_modules/@dojo' }
-			]
-		});
+		require.config(shimAmdDependencies({
+			baseUrl: baseUrl
+		}));
 
 		require(['_build/src/support/queue'], function (queue) {
 			queue.queueTask(function() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
 		"moduleResolution": "node",
 		"strictNullChecks": true,
 		"noImplicitThis": true,
-		"noEmitHelpers": true,
+		"importHelpers": true,
 		"types": [ "intern" ]
 	},
 	"include": [


### PR DESCRIPTION
Replacing `noEmitHelpers` with `importHelpers`. We need this for compatibility with webpack. Including the patch to tslib to update `__values` for string iteration.

We still want to load `@dojo/shim/main` first as it is going to load all the required polyfills. The only real downstream change here is that we'll be setting `importHelpers: true` instead of `noEmitHelpers: true`.

When this has landed, I'll merge / update `core`, then we can get to widget-core.