### PR TITLE
Adding checks for array like

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1,4 +1,4 @@
-import { Iterable, IterableIterator, ShimIterator } from './iterator';
+import { isArrayLike, Iterable, IterableIterator, ShimIterator } from './iterator';
 import global from './global';
 import { is as objectIs } from './object';
 import has from './support/has';
@@ -144,10 +144,18 @@ if (!has('es6-map')) {
 
 		static [Symbol.species] = Map;
 
-		constructor(iterable?: ArrayLike<[K, V]> | Iterable<[K, V]>) {
+		constructor(iterable?: ArrayLike<[ K, V ]> | Iterable<[ K, V ]>) {
 			if (iterable) {
-				for (const value of iterable) {
-					this.set(value[0], value[1]);
+				if (isArrayLike(iterable)) {
+					for (let i = 0; i < iterable.length; i++) {
+						const value = iterable[ i ];
+						this.set(value[ 0 ], value[ 1 ]);
+					}
+				}
+				else {
+					for (const value of iterable) {
+						this.set(value[ 0 ], value[ 1 ]);
+					}
 				}
 			}
 		}

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -149,12 +149,12 @@ if (!has('es6-map')) {
 				if (isArrayLike(iterable)) {
 					for (let i = 0; i < iterable.length; i++) {
 						const value = iterable[ i ];
-						this.set(value[ 0 ], value[ 1 ]);
+						this.set(value[0], value[1]);
 					}
 				}
 				else {
 					for (const value of iterable) {
-						this.set(value[ 0 ], value[ 1 ]);
+						this.set(value[0], value[1]);
 					}
 				}
 			}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -485,7 +485,7 @@ if (!has('es-observable')) {
 					return new constructor((observer: SubscriptionObserver<U>) => {
 						if (isArrayLike(item)) {
 							for (let i = 0; i < item.length; i++) {
-								observer.next(item[ i ]);
+								observer.next(item[i]);
 							}
 						}
 						else {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { Iterable, isIterable, isArrayLike } from './iterator';
+import { isArrayLike, isIterable, Iterable } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -483,8 +483,15 @@ if (!has('es-observable')) {
 				}
 				else if (isIterable(item) || isArrayLike(item)) {
 					return new constructor((observer: SubscriptionObserver<U>) => {
-						for (const o of item) {
-							observer.next(o);
+						if (isArrayLike(item)) {
+							for (let i = 0; i < item.length; i++) {
+								observer.next(item[ i ]);
+							}
+						}
+						else {
+							for (const o of item) {
+								observer.next(o);
+							}
 						}
 						observer.complete();
 					});

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { IterableIterator, Iterable, ShimIterator } from './iterator';
+import { isArrayLike, Iterable, IterableIterator, ShimIterator } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -110,8 +110,15 @@ if (!has('es6-set')) {
 
 		constructor(iterable?: ArrayLike<T> | Iterable<T>) {
 			if (iterable) {
-				for (const value of iterable) {
-					this.add(value);
+				if (isArrayLike(iterable)) {
+					for (let i = 0; i < iterable.length; i++) {
+						this.add(iterable[ i ]);
+					}
+				}
+				else {
+					for (const value of iterable) {
+						this.add(value);
+					}
 				}
 			}
 		};

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -112,7 +112,7 @@ if (!has('es6-set')) {
 			if (iterable) {
 				if (isArrayLike(iterable)) {
 					for (let i = 0; i < iterable.length; i++) {
-						this.add(iterable[ i ]);
+						this.add(iterable[i]);
 					}
 				}
 				else {

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -1,5 +1,5 @@
 import global from './global';
-import { Iterable } from './iterator';
+import { isArrayLike, Iterable } from './iterator';
 import has from './support/has';
 import './Symbol';
 
@@ -103,8 +103,16 @@ if (!has('es6-weakmap')) {
 			this._frozenEntries = [];
 
 			if (iterable) {
-				for (const [key, value] of iterable) {
-					this.set(key, value);
+				if (isArrayLike(iterable)) {
+					for (let i = 0; i < iterable.length; i++) {
+						const item = iterable[ i ];
+						this.set(item[ 0 ], item[ 1 ]);
+					}
+				}
+				else {
+					for (const [ key, value ] of iterable) {
+						this.set(key, value);
+					}
 				}
 			}
 		}

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -105,8 +105,8 @@ if (!has('es6-weakmap')) {
 			if (iterable) {
 				if (isArrayLike(iterable)) {
 					for (let i = 0; i < iterable.length; i++) {
-						const item = iterable[ i ];
-						this.set(item[ 0 ], item[ 1 ]);
+						const item = iterable[i];
+						this.set(item[0], item[1]);
 					}
 				}
 				else {

--- a/src/array.ts
+++ b/src/array.ts
@@ -207,13 +207,13 @@ else {
 			}
 
 			for (let i = 0; i < arrayLike.length; i++) {
-				array[ i ] = mapFunction ? mapFunction(arrayLike[ i ], i) : arrayLike[ i ];
+				array[i] = mapFunction ? mapFunction(arrayLike[i], i) : arrayLike[i];
 			}
 		}
 		else {
 			let i = 0;
 			for (const value of arrayLike) {
-				array[ i ] = mapFunction ? mapFunction(value, i) : value;
+				array[i] = mapFunction ? mapFunction(value, i) : value;
 				i++;
 			}
 		}

--- a/src/array.ts
+++ b/src/array.ts
@@ -201,14 +201,21 @@ else {
 
 		// if this is an array and the normalized length is 0, just return an empty array. this prevents a problem
 		// with the iteration on IE when using a NaN array length.
-		if (isArrayLike(arrayLike) && length === 0) {
-			return [];
-		}
+		if (isArrayLike(arrayLike)) {
+			if (length === 0) {
+				return [];
+			}
 
-		let i = 0;
-		for (const value of arrayLike) {
-			array[i] = mapFunction ? mapFunction(value, i) : value;
-			i++;
+			for (let i = 0; i < arrayLike.length; i++) {
+				array[ i ] = mapFunction ? mapFunction(arrayLike[ i ], i) : arrayLike[ i ];
+			}
+		}
+		else {
+			let i = 0;
+			for (const value of arrayLike) {
+				array[ i ] = mapFunction ? mapFunction(value, i) : value;
+				i++;
+			}
 		}
 
 		if ((<any> arrayLike).length !== undefined) {


### PR DESCRIPTION
Adding checks for array-like objects. Not only is this an optimization for arrays but it also causes a successful build using `esnext`.