### PR TITLE
remove the tslint prettier plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/shim",
-  "version": "0.2.5",
+  "version": "0.2.6-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,9 +35,9 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.4.tgz",
-      "integrity": "sha512-zb6OoQR7dzdc1Z/JojTDJFCIjLi2wt611WGBxn2U49fg7HWuglAMwdAT7fXwIADaQMnwyl9FoIn8MVUQTx/Ksw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
+      "integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
       "dev": true,
       "requires": {
         "intersection-observer": "0.4.3",
@@ -54,10 +54,18 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.4",
+        "@dojo/shim": "0.2.5",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "@theintern/leadfoot": {
@@ -69,7 +77,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.4",
+        "@dojo/shim": "0.2.5",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.1"
@@ -653,7 +661,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000792",
+        "caniuse-db": "1.0.30000793",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -999,8 +1007,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000792",
-        "electron-to-chromium": "1.3.30"
+        "caniuse-db": "1.0.30000793",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "buffer": {
@@ -1063,15 +1071,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000792",
+        "caniuse-db": "1.0.30000793",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000792",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000792.tgz",
-      "integrity": "sha1-p9rG3J9RgbZ1/Wnlywb++1IxV/g=",
+      "version": "1.0.30000793",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000793.tgz",
+      "integrity": "sha1-PADGbkI6ehkHx92Wdpp4sq+opy4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1548,7 +1556,7 @@
       "requires": {
         "es6-promise": "2.3.0",
         "lodash": "3.10.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "xml2js": "0.4.19"
       },
       "dependencies": {
@@ -1973,20 +1981,11 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "electron-releases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
-      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
-      "dev": true
-    },
     "electron-to-chromium": {
-      "version": "1.3.30",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
-      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
-      "dev": true,
-      "requires": {
-        "electron-releases": "2.1.0"
-      }
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -2065,16 +2064,6 @@
             "amdefine": "1.0.1"
           }
         }
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz",
-      "integrity": "sha512-L06bewYpt2Wb8Uk7os8f/0cL5DjddL38t1M/nOpjw5MqVFBn1RIIBBE6tfr37lHUH7AvAubZsvu/bDmNl4RBKQ==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
       }
     },
     "esprima": {
@@ -2239,12 +2228,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2972,7 +2955,7 @@
         "lodash": "2.4.1",
         "ncp": "0.5.1",
         "rimraf": "2.2.6",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-bom": "2.0.0",
         "typescript": "1.8.9",
         "underscore": "1.5.1",
@@ -3276,7 +3259,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.4",
+        "@dojo/shim": "0.2.5",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
@@ -3868,7 +3851,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -3942,12 +3925,6 @@
         "handlebars": "4.0.11"
       }
     },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
-    },
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
@@ -4004,9 +3981,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.1.tgz",
+      "integrity": "sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA==",
       "dev": true
     },
     "js-tokens": {
@@ -4833,7 +4810,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -5151,7 +5128,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -5472,7 +5449,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.1",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -6737,9 +6714,9 @@
       }
     },
     "rc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.3.tgz",
-      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -6912,7 +6889,7 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.3",
+        "rc": "1.2.4",
         "safe-buffer": "5.1.1"
       }
     },
@@ -6922,7 +6899,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.3"
+        "rc": "1.2.4"
       }
     },
     "regjsgen": {
@@ -7128,9 +7105,9 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "semver-diff": {
@@ -7139,7 +7116,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -7823,9 +7800,9 @@
         "glob": "7.1.2",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "tslib": "1.8.1",
-        "tsutils": "2.18.0"
+        "tsutils": "2.19.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7899,24 +7876,14 @@
           }
         },
         "tsutils": {
-          "version": "2.18.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.18.0.tgz",
-          "integrity": "sha512-y0CUDPPb0ygkUkmK8kAeLibag7OEAO0dxbtqAhzP+5w/VY5JdGnPiafhYxzRzWzkAGQGPJV99xrxngJYVLtrMg==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.19.0.tgz",
+          "integrity": "sha512-qjgvrvtzRUtOmqlZTfBFtep6s+ymuBLsHOC4ee9JNA+AZIbnR/x4C2Y7QFhOGpD2R3lDp0BBcnxb0vnMVrU7Aw==",
           "dev": true,
           "requires": {
             "tslib": "1.8.1"
           }
         }
-      }
-    },
-    "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-prettier": "2.5.0",
-        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -9249,7 +9216,7 @@
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
         "promise-finally": "2.2.1",
-        "rc": "1.2.3",
+        "rc": "1.2.4",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "lint-staged": "6.0.0",
     "prettier": "1.9.2",
     "tslint": "5.8.0",
-    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },
   "dependencies": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
-		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

With the commit hook for formatting typescript files with prettier, having the tslint plugin actually hinders development and basically masks actual linting issues (as people will just ignore the errors until prettier is run or the files are committed).

This change removes the plugin.

References https://github.com/dojo/meta/issues/206