### PR TITLE
Add webAnimation package details to shim

### DIFF
--- a/src/util/amd.ts
+++ b/src/util/amd.ts
@@ -33,7 +33,6 @@ function shimAmdDependencies(config: any) {
 		location: 'node_modules/web-animations-js'
 	});
 
-
 	addIfNotPresent(packages, {
 		name: '@dojo',
 		location: 'node_modules/@dojo'

--- a/src/util/amd.ts
+++ b/src/util/amd.ts
@@ -29,6 +29,12 @@ function shimAmdDependencies(config: any) {
 	});
 
 	addIfNotPresent(packages, {
+		name: 'web-animations-js',
+		location: 'node_modules/web-animations-js'
+	});
+
+
+	addIfNotPresent(packages, {
 		name: '@dojo',
 		location: 'node_modules/@dojo'
 	});

--- a/tests/functional/amd.ts
+++ b/tests/functional/amd.ts
@@ -23,12 +23,13 @@ registerSuite('AMD Util', {
 				undefined
 			)
 			.then((config: any) => {
-				assert.lengthOf(config.packages, 5);
+				assert.lengthOf(config.packages, 6);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'pepjs'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'tslib'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'intersection-observer'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === '@dojo'), 1);
 				assert.lengthOf(config.packages.filter((p: any) => p.name === 'existingPackage'), 1);
+				assert.lengthOf(config.packages.filter((p: any) => p.name === 'web-animations-js'), 1);
 			});
 	},
 	async 'Utility does not inject dependency if it already exists'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)<Paste>
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `web-animation-js` package details to shim so that they can be removed from `widget-core` and other loader configs
