### PR TITLE
Add Shims for AbortController and AbortSignal

### DIFF
--- a/src/AbortController.ts
+++ b/src/AbortController.ts
@@ -1,0 +1,109 @@
+import global from '@dojo/shim/global';
+import has from './support/has';
+import { findIndex } from '@dojo/shim/array';
+
+export interface AbortSignal extends EventTarget {
+	aborted: boolean;
+	onabort: (ev: Event) => any;
+}
+
+export interface AbortSignalConstructor {
+	readonly prototype: AbortSignal;
+	new (): AbortSignal;
+}
+
+// tslint:disable-next-line variable-name
+export let ShimAbortSignal: AbortSignalConstructor = global.AbortSignal;
+
+if (!has('abort-signal')) {
+	global.AbortSignal = ShimAbortSignal = class implements AbortSignal {
+		private _aborted = false;
+		onabort: (ev: Event) => any;
+
+		listeners: { [type: string]: ((event: Event) => void)[] } = {};
+
+		get aborted(): boolean {
+			return this._aborted;
+		}
+
+		addEventListener(type: string, callback: (event: Event) => void): void {
+			if (!(type in this.listeners)) {
+				this.listeners[type] = [];
+			}
+			this.listeners[type].push(callback);
+		}
+
+		removeEventListener(type: string, callback: (event: any) => void): void {
+			if (!(type in this.listeners)) {
+				return;
+			}
+
+			const index = findIndex(this.listeners[type], (cb: (event: any) => void) => cb === callback);
+
+			if (index >= 0) {
+				this.listeners[type].splice(index, 1);
+			}
+		}
+
+		dispatchEvent(event: Event): boolean {
+			const { type } = event;
+			if (type === 'abort') {
+				this._aborted = true;
+				if (typeof this.onabort === 'function') {
+					this.onabort.call(this, event);
+				}
+			}
+
+			if (!(type in this.listeners)) {
+				return false;
+			}
+
+			this.listeners[type].forEach((callback: (event: any) => void) => {
+				setTimeout(() => callback.call(this, event));
+			});
+
+			return !event.preventDefault;
+		}
+	};
+}
+
+export interface AbortController {
+	readonly signal: AbortSignal;
+	abort(): void;
+}
+
+export interface AbortControllerConstructor {
+	readonly prototype: AbortController;
+	new (): AbortController;
+}
+
+// tslint:disable-next-line variable-name
+export let ShimAbortController: AbortControllerConstructor = global.AbortController;
+
+if (!has('abort-controller')) {
+	global.AbortController = ShimAbortController = class implements AbortController {
+		readonly signal: AbortSignal = new ShimAbortSignal();
+
+		abort(): void {
+			let event: Event;
+			try {
+				event = new Event('abort');
+			} catch (e) {
+				if (typeof document !== 'undefined') {
+					event = document.createEvent('Event');
+					event.initEvent('abort', false, false);
+				} else {
+					event = {
+						type: 'abort',
+						bubbles: false,
+						cancelable: false
+					} as Event;
+				}
+			}
+
+			this.signal.dispatchEvent(event);
+		}
+	};
+}
+
+export default ShimAbortController;

--- a/src/support/has.ts
+++ b/src/support/has.ts
@@ -263,3 +263,7 @@ add(
 	() => has('host-browser') && global.Animation !== undefined && global.KeyframeEffect !== undefined,
 	true
 );
+
+add('abort-controller', () => typeof global.AbortController !== 'undefined');
+
+add('abort-signal', () => typeof global.AbortSignal !== 'undefined');

--- a/tests/unit/AbortController.ts
+++ b/tests/unit/AbortController.ts
@@ -1,0 +1,94 @@
+import { AbortController, AbortSignal, ShimAbortController, ShimAbortSignal } from '../../src/AbortController';
+import global from '../../src/global';
+
+let controller: AbortController;
+let signal: AbortSignal;
+
+import has from '../../src/support/has';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+registerSuite('AbortController and AbortSignal', {
+	beforeEach() {
+		controller = new ShimAbortController();
+		signal = controller.signal;
+	},
+	tests: {
+		'native AbortController'() {
+			if (!has('abort-controller')) {
+				this.skip('checking native implementation');
+			}
+			assert.include(
+				ShimAbortController.toString(),
+				'native',
+				'native implementation should represent native code'
+			);
+		},
+
+		'native AbortSignal'() {
+			if (!has('abort-signal')) {
+				this.skip('checking native implementation');
+			}
+			assert.include(ShimAbortSignal.toString(), 'native', 'native implementation should represent native code');
+		},
+
+		'AbortController defaults'() {
+			assert.isFunction(controller.abort, 'should provide an `abort` method');
+			assert.isDefined(controller.signal, 'should provide a signal property');
+		},
+
+		'AbortSignal defaults'() {
+			assert.isFalse(signal.aborted);
+			assert.notExists(signal.onabort);
+		},
+
+		'abort event'() {
+			const dfd = this.async();
+			signal.addEventListener(
+				'abort',
+				dfd.callback((event: Event) => {
+					assert.strictEqual(event.type, 'abort');
+					assert.isTrue(signal.aborted);
+				})
+			);
+			controller.abort();
+		},
+
+		'onabort method callback'() {
+			const dfd = this.async();
+			signal.onabort = dfd.callback((event: Event) => {
+				assert.strictEqual(event.type, 'abort');
+			});
+			controller.abort();
+		},
+
+		'remove event listener'() {
+			let called = false;
+			const callback = () => (called = true);
+			signal.addEventListener('abort', callback);
+			signal.removeEventListener('abort', callback);
+			controller.abort();
+			assert.isFalse(called, 'callback should not have been called');
+		},
+
+		'dispatch event'() {
+			return new Promise((resolve) => {
+				let called = 0;
+				const expectedCalls = 2;
+				const createEvent = (type: string) => (global.Event ? new Event(type) : ({ type } as Event));
+				const callback = () => {
+					called++;
+					if (called === expectedCalls) {
+						assert.strictEqual(called, 2, 'should be called twice');
+						resolve();
+					}
+				};
+				signal.onabort = callback;
+				signal.addEventListener('abort', callback);
+				signal.dispatchEvent(createEvent('test'));
+				signal.dispatchEvent(createEvent('abort'));
+			});
+		}
+	}
+});

--- a/tests/unit/AbortController.ts
+++ b/tests/unit/AbortController.ts
@@ -76,7 +76,25 @@ registerSuite('AbortController and AbortSignal', {
 			return new Promise((resolve) => {
 				let called = 0;
 				const expectedCalls = 2;
-				const createEvent = (type: string) => (global.Event ? new Event(type) : ({ type } as Event));
+				const createEvent = (type: string) => {
+					let event: Event;
+					try {
+						event = new Event(type);
+					} catch (e) {
+						if (typeof document !== 'undefined') {
+							event = document.createEvent('Event');
+							event.initEvent(type, false, false);
+						}
+						else {
+							event = {
+								type,
+								bubbles: false,
+								cancelable: false
+							} as Event;
+						}
+					}
+					return event;
+				};
 				const callback = () => {
 					called++;
 					if (called === expectedCalls) {

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -2,6 +2,7 @@ import './support/decorators';
 import './support/has';
 import './support/queue';
 import './support/util';
+import './AbortController';
 import './array';
 import './global';
 import './iterator';

--- a/tests/unit/support/has.ts
+++ b/tests/unit/support/has.ts
@@ -26,7 +26,9 @@ registerSuite('support/has', {
 			'microtasks',
 			'postmessage',
 			'raf',
-			'setimmediate'
+			'setimmediate',
+			'abort-controller',
+			'abort-signal'
 		].forEach((feature) => assert.isTrue(exists(feature)));
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue dojo/core#390
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)<Paste>
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds a shim for `AbortController` and `AbortSignal`, which will be used by `@dojo/core/request` as discussed in dojo/core#390.

- add AbortController and AbortSignal shims
- add unit tests